### PR TITLE
Fix units label handling

### DIFF
--- a/scripts/labels.yml
+++ b/scripts/labels.yml
@@ -21,7 +21,7 @@
 - {color: 71bc1c, description: 'terminal plugin', name: terminal}
 - {color: 71bc1c, description: 'tests', name: tests}
 - {color: 71bc1c, description: 'tests/integration', name: integration}
-- {color: 71bc1c, description: 'tests/units', name: units}
+- {color: 71bc1c, description: 'tests/unit', name: units}
 - {color: 71bc1c, description: 'vars plugin', name: vars}
 - {color: 73d15c, description: 'Good for new comers and easy to start with contribution', name: easyfix}
 - {color: 8aea94, description: 'Help guide this first time contributor', name: new_contributor}


### PR DESCRIPTION
##### SUMMARY
I noticed that the bot doesn't put `units` label when a PR contains unit tests, e.g. in https://github.com/ansible-collections/community.general/pull/1099/files)
This is because of the path difference in ansible/ansible (`test/units`) and collections (`test/unit`).

I'm not sure it'll work as expected. Didn't find any other places where the path is determined.
Could anyone give me a hint if there is any guide how to run unit tests for the bot locally?

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`scripts/labels.yml`
