### PR TITLE
Don't spam maintainers in same directory

### DIFF
--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -137,6 +137,11 @@ def get_automerge_facts(issuewrapper, meta):
 def needs_community_review(meta, issue):
     '''Notify community for more shipits?'''
 
+    # Don't spam requesting reviews from maintainers of
+    # Other modules in this directory - gundalow
+    return False
+
+
     if not meta[u'is_new_module']:
         return False
 


### PR DESCRIPTION
##### SUMMARY
Given what we've seen, asking for review on new-modules from other maintainers seems to be considered spam, so stop doing it.

fixes: #18


##### ISSUE TYPE
- Bugfix Pull Request
