### PR TITLE
Delete repo_data

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -110,10 +110,6 @@ CREPOS = [
     u'ansible-collections/windows',
 ]
 
-repo_data = {'ansible-collections/community.general': {'branch': 'master', 'shippable_prj' : '5e664a167c32620006c9fa50'},
-        }
-
-
 MREPOS = [x for x in REPOS if u'ansible' in x]
 REPOMERGEDATE = datetime.datetime(2016, 12, 6, 0, 0, 0)
 MREPO_CLOSE_WINDOW = 60
@@ -868,7 +864,7 @@ class AnsibleTriage(DefaultTriager):
             if iw.is_issue() and self.meta.get(u'needs_component_message'):
                 tvars = {
                     u'meta': self.meta,
-                    u'base_url': 'https://github.com/%s/blob/%s/' % (self.collection,repo_data[self.collection][u'branch']),
+                    u'base_url': 'https://github.com/%s/blob/main/' % (self.collection),
                 }
                 comment = self.render_boilerplate(
                     tvars, boilerplate=u'components_banner'


### PR DESCRIPTION
repo_data was only used for:
1. Shippable (no longer used)
2. Branch name (we used `main` everywhere now)

Therefore we can delete it
